### PR TITLE
Added portuguese translation to solve issue #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Check out our live demo here: [Pokedex-v2 Live Demo](https://pokedex.mario-kreit
 - **Detailed Pokémon Information**: 📜 Get comprehensive details such as held items, availability by edition, and more!
 - **Angular 17**: 🚀 Built with the latest version of Angular for improved performance and developer experience.
 - **pokeapi-js-wrapper**: 🔌 Seamlessly integrated with `pokeapi-js-wrapper` for more flexible and powerful API interactions.
-- **Localization**: 🌐 Available in English (default) and German.
+- **Localization**: 🌐 Available in English (default), German and Portuguese.
 
 ## New in Version 2.2.0 🚀
 

--- a/src/app/components/credits/credits.component.html
+++ b/src/app/components/credits/credits.component.html
@@ -122,7 +122,7 @@
     </li>
   </ul>
 </div>
-} @else {
+} @else if (language == "de") {
 <div class="navigation">
   <p>Drücke ESC, um zurückzugehen</p>
 </div>
@@ -251,4 +251,128 @@
     </li>
   </ul>
 </div>
+} @else if (language == "pt") {
+  <div class="navigation">
+    <p>aperte ESC para retornar</p>
+  </div>
+  <div class="content">
+    <h1>Agradecimentos especiais</h1>
+    <ul class="thanks-list">
+      <li>
+        <a target="_blank" href="https://pokeapi.co/">
+          <img
+            class="logo logo-pokeapi-big"
+            src="https://raw.githubusercontent.com/PokeAPI/media/master/logo/pokeapi.svg"
+            alt="PokeAPI"
+          />
+          PokeAPI</a
+        >
+        por fornecer dados para todos os Pokemón, incluindo seus status, golpes, 
+        tipos e mais
+      </li>
+      <li>
+        <a target="_blank" href="https://github.com/PokeAPI/sprites">
+          <img
+            class="logo logo-pokeapi-small"
+            src="https://avatars.githubusercontent.com/u/19692032?s=48&v=4"
+            alt="PokeAPI-sprites"
+          />
+          PokeAPI-sprites</a
+        >
+        por fornecer os sprites oficiais dos Pokémon
+      </li>
+      <li>
+        <a target="_blank" href="https://github.com/PokeAPI/cries">
+          <img
+            class="logo logo-pokeapi-small"
+            src="https://avatars.githubusercontent.com/u/19692032?s=48&v=4"
+            alt="PokeAPI-cries"
+          />
+          PokeAPI-cries</a
+        >
+        por fornecer os sons oficiais dos Pokémon
+      </li>
+      <li>
+        <a target="_blank" href="https://www.instagram.com/18ago/">
+          <img
+            class="logo profile"
+            src="./assets/franziska_wessely_pb.jpeg"
+            alt="Franziska Wessely"
+          />
+          Franziska Wessely</a
+        >
+        por fornecer o design
+      </li>
+      <li>
+        <a target="_blank" href="https://pixabay.com/">
+          <img
+            class="logo logo-pixabay"
+            src="./assets/pixabay_logo.svg"
+            alt="Pixabay"
+          />
+          Pixabay</a
+        >
+        por fornecer os efeitos sonoros usados na aplicação
+      </li>
+    </ul>
+    <h2>Executado por</h2>
+    <p>
+      <a target="_blank" href="https://github.com/mariokreitz">
+        <img
+          class="logo profile"
+          src="https://avatars.githubusercontent.com/u/48879876?s=96&v=4"
+          alt="Mario Kreitz"
+        />
+        Mario Kreitz</a
+      >
+      pela implementação técnica
+    </p>
+    <h2>Estruturado por</h2>
+    <ul class="thanks-list">
+      <li>
+        <a target="_blank" href="https://angular.io/">
+          <img
+            class="logo logo-angular"
+            src="https://avatars.githubusercontent.com/u/139426?s=200&v=4"
+            alt="Angular 17"
+          />
+          Angular 17</a
+        >
+        por fornecer a framework usada para construir esta aplicação
+      </li>
+      <li>
+        <a target="_blank" href="https://github.com/PokeAPI/pokeapi-js-wrapper">
+          <img
+            class="logo logo-pokeapi-small"
+            src="https://avatars.githubusercontent.com/u/19692032?s=48&v=4"
+            alt="pokeapi-js-wrapper"
+          />
+          pokeapi-js-wrapper</a
+        >
+        por fornecer uma forma conveniente de interagir com a PokeAPI
+      </li>
+      <li>
+        <a target="_blank" href="https://www.chartjs.org/">
+          <img
+            class="logo logo-chartjs"
+            src="https://www.chartjs.org/img/chartjs-logo.svg"
+            alt="ChartJS"
+          />
+          ChartJS</a
+        >
+        por fornecer a biblioteca gráfica usada na ficha dos Pokémon
+      </li>
+      <li>
+        <a target="_blank" href="https://github.com/microsoft/TypeScript">
+          <img
+            class="logo logo-typescript"
+            src="https://avatars.githubusercontent.com/u/6154722?s=48&v=4"
+            alt="TypeScript"
+          />
+          Microsoft TypeScript</a
+        >
+        por fornecer o sistema tipado usado nesta aplicação
+      </li>
+    </ul>
+  </div>
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -12,7 +12,7 @@
         name="searchbar"
         id="searchbar"
         aria-label="Searchbar"
-        [placeholder]="language === 'en' ? 'Search...' : 'Suche...'"
+        [placeholder]="searchPlaceholders[language]"
         tabindex="0"
         #searchbar
         aria-autocomplete="list"

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -19,6 +19,13 @@ import { PokemonService } from '../../services/pokemon.service';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnInit {
+  // Text for the search input
+  searchPlaceholders: { [key: string]: string } = {
+    en: 'Search...',
+    de: 'Suche...',
+    pt: 'Buscar...',
+  };
+
   /**
    * Initializes the HeaderComponent with the necessary services.
    *

--- a/src/app/components/imprint/imprint.component.html
+++ b/src/app/components/imprint/imprint.component.html
@@ -103,7 +103,7 @@
   </p>
 </div>
 <app-back-to-top />
-}@else {
+}@else if (language === "de") {
 <div class="navigation">
   <button (click)="navigateToHome()" type="button">Startseite</button>
 </div>
@@ -211,4 +211,107 @@
   </p>
 </div>
 <app-back-to-top />
-}
+} @if (language === "pt") {
+  <div class="navigation">
+    <button (click)="navigateToHome()" type="button">Início</button>
+  </div>
+  <div class="impressum">
+    <h1>Autoria</h1>
+    <p>Informação de acordo com o § 5 DDG</p>
+    <p>
+      Mario Kreitz <br />
+      Mönchfeldstraße 7<br />
+      70378 Stuttgart <br />
+    </p>
+    <p>
+      <strong>Represented by: </strong><br />
+      Mario Kreitz<br />
+    </p>
+    <p>
+      <strong>Contato:</strong> <br />
+      Email:
+      <a href="mailto:contact@mario-kreitz.dev">contact&#64;mario-kreitz.dev</a
+      ><br />
+    </p>
+    <p>
+      <strong>Isenção de responsabilidade: </strong><br /><br /><strong
+        >Responsabilidade do conteúdo</strong
+      ><br /><br />
+      Os conteúdos das nossas páginas foram criados com o máximo cuidado. Porém, nós
+      não podemos garantir a acurácia, completude e pontualidade do conteúdo.
+      Como fornecedores de serviços, somos responsáveis pelos nossos próprios conteúdos
+      nestas páginas de acordo com as leis gerais. De acordo com os §§ 8 a 10 DDG, nós
+      não somos obrigados a monitorar informações externas transmitidas ou armazenadas, ou
+      de investigar circunstâncias que indicam atividades ilegais. Obrigações para remover
+      ou bloquear o uso de informações de acordo com leis gerais se mantém inafetadas.
+      A responsabilidade de conteúdo neste aspecto só é possível no instante em que ficamos
+      cientes de uma violação legal específica. Através do aviso de tais violações legais, 
+      removeremos este conteúdo imediatamente.<br /><br /><strong
+        >Responsabilidade de conteúdo dos Links</strong
+      ><br /><br />
+      A nossa proposta contém links para páginas externas de terceiros, aos quais
+      não temos influência sobre os conteúdos. Assim, não podemos assumir nenhuma
+      responsabilidade por estes conteúdos externos. O respectivo fornecedor ou
+      operador destas páginas vinculadas sempre são responsáveis pelos conteúdos
+      destas páginas. As páginas anexadas através de link foram checadas para
+      possíveis violações legais durante o momento de citação. 
+      Ademais, um controle de conteúdo contínuo das páginas vinculadas não é justificável
+      sem uma evidência concreta de violação legal. Com a notificação de violações
+      legais, removeremos tais anexos imediatamente.<br /><br /><strong
+        >Direitos autorais</strong
+      ><br /><br />
+      Todos os dados vieram de <a href="https://pokeapi.co/">pokeapi.co</a>.<br />
+      Os sprites dos Pokemón e áudios vieram de
+      <a href="https://raw.githubusercontent.com/PokeAPI/"
+        >https://raw.githubusercontent.com/PokeAPI/</a
+      >.<br />
+      <br />
+      Se você ficar ciente de um infringimento de direitos autorais, nós gentilmente
+      solicitamos que você nos solicite. Com a ciência de violações legais, nós
+      removeremos tais conteúdos imediatamente. Os conteúdos e trabalos criados pelos
+      operadores do site nestas páginas estão sujeitos à lei de direitos autorais
+      alemã. Duplicações, edições, distribuições, e quaisquer formas de uso além
+      dos limites de direitos autorais demandam o consentimento escrito dos respectivos
+      autores ou criadores. Downloads e cópias desta página só são permitidos para uso
+      privado e não comercial. Como os conteúdos desta página não foram criados pelo
+      operador, os direitos autoráis de terceiros são observados. Em particular, o conteúdo
+      de terceiros é marcado como tal. Se um conteúdo de terceiro for usado, os direitos
+      autorais da seguinte pessoa devem ser observados:<br />
+      Franziska Wessely (<a href="mailto:fru_tamm_93@yahoo.de"
+        >fru_tamm_93&#64;yahoo.de</a
+      >)<br />
+    </p>
+  
+    <ul>
+      <li>A figura gráfica de fundo</li>
+      <li>Os fundos dos cards e pop-ups</li>
+      <li>As imagens abaixo dos diagramas</li>
+    </ul>
+    <br />
+    Efeito sonoro por
+    <a
+      href="https://pixabay.com/de/users/xtremefreddy-32332307/?utm_source=link-attribution&utm_medium=referral&utm_campaign=music&utm_content=145285"
+      >Gaston A-P</a
+    >
+    de
+    <a
+      href="https://pixabay.com//?utm_source=link-attribution&utm_medium=referral&utm_campaign=music&utm_content=145285"
+      >Pixabay</a
+    >
+    <p>
+      Se você se tornar ciente de um infringimento de direitos autorais, nós gentilmente
+      pedimos que você nos notifique devidamente. Com a ciência de violações legais, nós
+      removeremos tais conteúdos imediatamente.
+    </p>
+  
+    <p>
+      <br />
+      Autoria de site criada por
+      <a href="https://www.impressum-generator.de">impressum-generator.de</a> de
+      <a href="https://www.kanzlei-hasselbach.de/" rel="nofollow"
+        >Kanzlei Hasselbach</a
+      >
+    </p>
+  </div>
+  <app-back-to-top />
+  }

--- a/src/app/components/pokemon-card/pokemon-card.component.html
+++ b/src/app/components/pokemon-card/pokemon-card.component.html
@@ -11,9 +11,11 @@
   <div class="types">
     @for (classType of classTypes; track $index) {
     <span [className]="'type' + ' ' + classType.english">{{
-      language === "en"
-        ? (classType.english | titlecase)
-        : (classType.german | titlecase)
+      language === 'en' 
+      ? (classType.english | titlecase)
+      : (language === 'de' 
+        ? (classType.german | titlecase) 
+        : (classType.portuguese | titlecase))
     }}</span
     >}
   </div>

--- a/src/app/components/pokemon-card/pokemon-card.component.ts
+++ b/src/app/components/pokemon-card/pokemon-card.component.ts
@@ -92,13 +92,14 @@ export class PokemonCardComponent {
   }
 
   /**
-   * Retrieves the types of the Pokémon, with their English and German names.
+   * Retrieves the types of the Pokémon, with their English, German and Portuguese names.
    *
-   * @returns {{ english: string; german: string }[]} An array of objects, each containing the English and German names of a type.
+   * @returns {{ english: string; german: string; portuguese: string }[]} An array of objects, each containing the English, German and Portuguese names of a type.
    */
   get classTypes(): {
     english: string;
     german: string;
+    portuguese: string;
   }[] {
     const types = this.Pokemon.types.map(({ type }) => type.name);
     const typesInLanguage = types.map((type) =>

--- a/src/app/components/pokemon-list/loading-big/loading-big.component.ts
+++ b/src/app/components/pokemon-list/loading-big/loading-big.component.ts
@@ -98,8 +98,6 @@ export class LoadingBigComponent implements OnInit {
    */
   private getRandomLoadingText(): string {
     const language = this.settingsService.getLanguage();
-    // const loadingTexts =
-      // language === 'de' ? this.loadingGermanText : this.loadingEnglishText;
 
     const loadingTexts = (() => {
       switch (language) {
@@ -108,7 +106,7 @@ export class LoadingBigComponent implements OnInit {
         case 'pt':
           return this.loadingPortugueseText;
         default:
-          return this.loadingEnglishText; // Fallback para inglês
+          return this.loadingEnglishText; // English as default
       }
     })();
 

--- a/src/app/components/pokemon-list/loading-big/loading-big.component.ts
+++ b/src/app/components/pokemon-list/loading-big/loading-big.component.ts
@@ -75,6 +75,22 @@ export class LoadingBigComponent implements OnInit {
     'Bereite dein Abenteuer vor. Unser Server ist auf eigener Quest!',
   ];
 
+    /**
+   * An array of loading texts in Portuguese.
+   * @type {string[]}
+   */
+    loadingPortugueseText: string[] = [
+      'Carregando... aguardando o Pikachu carregar!',
+      'Um momento. Nossos servidores estão tirando uma soneca como o Snorlax.',
+      'Obtendo dados... tomara que não seja um Ditto disfarçado!',
+      'Aquecendo o servidor com um Fire Blast!',
+      'Nossa tela de carregamento está evoluindo para uma versão mais rápida!',
+      'Procurando uma Master Ball para resolver isso logo!',
+      'Processando... tentando não ser pego na rede de um treinador!',
+      'Carregando... prometo que não é culpa do Slowpoke!',
+      'Preparando sua aventura. Nosso servidor está em sua própria missão!',
+    ];
+
   /**
    * Returns a random loading text based on the current language setting.
    *
@@ -82,8 +98,19 @@ export class LoadingBigComponent implements OnInit {
    */
   private getRandomLoadingText(): string {
     const language = this.settingsService.getLanguage();
-    const loadingTexts =
-      language === 'de' ? this.loadingGermanText : this.loadingEnglishText;
+    // const loadingTexts =
+      // language === 'de' ? this.loadingGermanText : this.loadingEnglishText;
+
+    const loadingTexts = (() => {
+      switch (language) {
+        case 'de':
+          return this.loadingGermanText;
+        case 'pt':
+          return this.loadingPortugueseText;
+        default:
+          return this.loadingEnglishText; // Fallback para inglês
+      }
+    })();
 
     return loadingTexts[Math.floor(Math.random() * loadingTexts.length)];
   }

--- a/src/app/components/pokemon-list/pokemon-list.component.html
+++ b/src/app/components/pokemon-list/pokemon-list.component.html
@@ -25,7 +25,7 @@
     class="overview-button"
     id="prev-pokemon"
     (click)="onPrevClick()"
-    [title]="language === 'en' ? 'Previous Pokemon' : 'Vorheriges Pokemon'"
+    [title]="previousPlaceholders[language]"
   >
     &#9001;
   </button>
@@ -35,7 +35,7 @@
     class="overview-button"
     id="next-pokemon"
     (click)="onNextClick()"
-    [title]="language === 'en' ? 'Next Pokemon' : 'Nächstes Pokemon'"
+    [title]="nextPlaceholders[language]"
   >
     &#9002;
   </button>

--- a/src/app/components/pokemon-list/pokemon-list.component.ts
+++ b/src/app/components/pokemon-list/pokemon-list.component.ts
@@ -25,6 +25,18 @@ import { LoadingBigComponent } from './loading-big/loading-big.component';
   styleUrl: './pokemon-list.component.scss',
 })
 export class PokemonListComponent implements OnInit {
+  // Texts for previous and next pokemon
+  previousPlaceholders: { [key: string]: string } = {
+    en: 'Previous Pokémon',
+    de: 'Vorheriges Pokémon',
+    pt: 'Pokémon anterior',
+  };
+  nextPlaceholders: { [key: string]: string } = {
+    en: 'Next Pokémon',
+    de: 'Nächstes Pokémon',
+    pt: 'Próximo Pokémon',
+  };
+
   /**
    * Whether the Pokémon's cry is currently playing.
    */

--- a/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.html
+++ b/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.html
@@ -47,12 +47,16 @@
           [title]="
             language === 'en'
               ? (type.english | titlecase)
-              : (type.german | titlecase)
+              : (language === 'de' 
+                ? (type.german | titlecase) 
+                : (type.portuguese | titlecase))
           "
           >{{
-            language === "en"
-              ? (type.english | titlecase)
-              : (type.german | titlecase)
+            language === 'en' 
+            ? (type.english | titlecase)
+            : (language === 'de' 
+              ? (type.german | titlecase) 
+              : (type.portuguese | titlecase))
           }}</span
         >}
       </div>
@@ -84,13 +88,7 @@
       </div>
       <div id="items" class="tabcontent">
         @if (items) { @if (items.length > 0) {
-        <h4>
-          {{
-            language === "en"
-              ? "Possible items to receive upon catching"
-              : "Mögliche Gegenstände, die man beim Fangen erhalten kann"
-          }}
-        </h4>
+        <h4>{{ getLabel('items', language) }}</h4>
         @for (item of items; track $index) {
         <div class="item">
           <label class="item-label" [title]="selectedItemFlavorText($index)">
@@ -107,35 +105,17 @@
           </label>
         </div>
         }@empty {
-        <p>
-          {{
-            language === "en"
-              ? "Snorlax must have eaten all the items!"
-              : "Snorlax muss alle Gegenstände aufgegessen haben!"
-          }}
-        </p>
+        <p>{{ getLabel('no_items1', language) }}</p>
         }} @else {
-        <p>
-          {{
-            language === "en"
-              ? "It seems this Pokémon doesn't come with any items!"
-              : "Es scheint, als käme dieses Pokémon ohne Gegenstände!"
-          }}
-        </p>
+        <p>{{ getLabel('no_items2', language) }}</p>
         }} @else {
-        <p>
-          {{
-            language === "en"
-              ? "All Pokémon used Fly and flew off with the items!"
-              : "Alle Pokémon haben Fliegen eingesetzt und sind mit den Gegenständen davon geflogen!"
-          }}
-        </p>
+        <p>{{ getLabel('no_items3', language) }}</p>
         }
       </div>
       <div id="editions" class="tabcontent">
         <div class="wrapper">
           @if (game_indices) { @if (game_indices.length > 0) {
-          <h4>{{ language === "en" ? "Released in" : "Erschienen in" }}</h4>
+            <h4>{{ getLabel('released', language) }}</h4>
           <div class="content">
             @for (game of game_indices; track $index) {
             <p>{{ game.version.name | titlecase }}</p>
@@ -193,13 +173,11 @@
   </div>
   <div class="footer">
     <div class="info">
-      <h4>{{ language === "en" ? "Description" : "Beschreibung" }}</h4>
+      <h4>{{ getLabel('description', language) }}</h4>
       <p>{{ getSelectedLanguageDescription }}</p>
     </div>
     <div class="passiv-ability">
-      <h4>
-        {{ language === "en" ? "Passive Ability" : "Passive Fähigkeit" }}
-      </h4>
+      <h4>{{ getLabel('ability', language) }}</h4>
       @for (ability of abilities; track $index) {
       <span
         >{{ ability.ability.name | titlecase }} ({{

--- a/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.html
+++ b/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.html
@@ -144,7 +144,7 @@
           class="tablinks"
           src="./assets/graph.png"
           alt="Graph Icon"
-          title="Stats"
+          title="{{ getLabel('t_stats', language) }}"
           loading="lazy"
           decoding="auto"
         />
@@ -154,7 +154,7 @@
           class="tablinks"
           src="./assets/bag.png"
           alt="Bag Icon"
-          title="Items"
+          title="{{ getLabel('t_items', language) }}"
           loading="lazy"
           decoding="auto"
         />
@@ -164,7 +164,7 @@
           class="tablinks"
           src="./assets/gb_cartridge.png"
           alt="Gameboy Cartridge Icon"
-          title="Editions"
+          title="{{ getLabel('t_edition', language) }}"
           loading="lazy"
           decoding="auto"
         />

--- a/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.ts
+++ b/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.ts
@@ -30,7 +30,43 @@ import { PokemonService } from '../../../services/pokemon.service';
  * @prop {string} selectedPokemonLanguageName - The name of the Pokémon in the current language.
  * @prop {string} selectedPokemonLanguageDescription - The description of the Pokémon in the current language.
  */
-export class PokemonPopupComponent implements OnInit {
+  export class PokemonPopupComponent implements OnInit {
+    // Inserting a dictionary of translations for each language
+    getLabel = (key: string, language: string): string => {
+      const translations_dict: { [key: string]: { [key: string]: string } } = {
+        en: {
+          items: "Possible items to receive upon catching",
+          no_items1: "Snorlax must have eaten all the items!",
+          no_items2: "It seems this Pokémon doesn't come with any items!",
+          no_items3: "All Pokémon used Fly and flew off with the items!",
+          released: "Released in",
+          description: "Description",
+          ability: "Passive Hability",
+        },
+        de: {
+          items: "Mögliche Gegenstände, die man beim Fangen erhalten kann",
+          no_items1: "Snorlax muss alle Gegenstände aufgegessen haben!",
+          no_items2: "Es scheint, als käme dieses Pokémon ohne Gegenstände!",
+          no_items3: "Alle Pokémon haben Fliegen eingesetzt und sind mit den Gegenständen davon geflogen!",
+          released: "Erschienen in",
+          description: "Beschreibung",
+          ability: "Passive Fähigkeit",
+        },
+        pt: {
+          items: "Possíveis itens obtidos com a captura",
+          no_items1: "Snorlax parece ter comido todos os itens!",
+          no_items2: "Este Pokémon parece não vir com itens!",
+          no_items3: "Todos os Pokémon usaram Fly e fugiram com os itens!",
+          released: "Aparece em",
+          description: "Descrição",
+          ability: "Habilidade Passiva",
+        }
+      };
+    
+      // If the translation exists, returns it, case contrary, returns english(default)
+      return translations_dict[language]?.[key] || translations_dict["en"][key];
+    }
+
   /**
    * The Pokémon to display.
    */
@@ -121,15 +157,24 @@ export class PokemonPopupComponent implements OnInit {
    */
   get getSelectedLanguageDescription(): string {
     if (!this.flavor_text_entries) return '';
+    
+    // If the language is portuguese, the Pokémon description is in spanish
+    let selectedLanguage = this.settingsService.getLanguage();
+    selectedLanguage = selectedLanguage === 'pt' ? 'es' : selectedLanguage;
+  
     const filteredDescriptions = this.flavor_text_entries.filter(
-      ({ language }) => language.name === this.settingsService.getLanguage()
+      ({ language }) => language.name === selectedLanguage
     );
+  
     if (!filteredDescriptions.length) return 'Keine übersetzung gefunden';
+    
     const descriptions = filteredDescriptions.map(
       ({ flavor_text }) => flavor_text
     );
+    
     return descriptions[0].replace('\f', '\n') || '';
   }
+  
 
   /**
    * The Pokémon's HP number.
@@ -154,10 +199,12 @@ export class PokemonPopupComponent implements OnInit {
    *
    * @property {string} english - The English name of the type.
    * @property {string} german - The German name of the type.
+   * @property {string} portuguese - The Portuguese name of the type.
    */
   types!: {
     english: string;
     german: string;
+    portuguese: string;
   }[];
 
   /**

--- a/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.ts
+++ b/src/app/components/pokemon-list/pokemon-popup/pokemon-popup.component.ts
@@ -40,8 +40,11 @@ import { PokemonService } from '../../../services/pokemon.service';
           no_items2: "It seems this Pokémon doesn't come with any items!",
           no_items3: "All Pokémon used Fly and flew off with the items!",
           released: "Released in",
+          t_stats: "Stats",
+          t_items: "Items",
+          t_edition: "Editions",
           description: "Description",
-          ability: "Passive Hability",
+          ability: "Passive Ability",
         },
         de: {
           items: "Mögliche Gegenstände, die man beim Fangen erhalten kann",
@@ -49,6 +52,9 @@ import { PokemonService } from '../../../services/pokemon.service';
           no_items2: "Es scheint, als käme dieses Pokémon ohne Gegenstände!",
           no_items3: "Alle Pokémon haben Fliegen eingesetzt und sind mit den Gegenständen davon geflogen!",
           released: "Erschienen in",
+          t_stats: "Stats",
+          t_items: "Items",
+          t_edition: "Editions",
           description: "Beschreibung",
           ability: "Passive Fähigkeit",
         },
@@ -58,6 +64,9 @@ import { PokemonService } from '../../../services/pokemon.service';
           no_items2: "Este Pokémon parece não vir com itens!",
           no_items3: "Todos os Pokémon usaram Fly e fugiram com os itens!",
           released: "Aparece em",
+          t_stats: "Status",
+          t_items: "Itens",
+          t_edition: "Edições",
           description: "Descrição",
           ability: "Habilidade Passiva",
         }
@@ -679,9 +688,15 @@ import { PokemonService } from '../../../services/pokemon.service';
    * @return {string} The name of the item in the current language.
    */
   selectedItemLanguageName(index: number): string {
+
+    let selectedLanguage = this.settingsService.getLanguage();
+    // If the language is portuguese, the item name is in spanish
+    selectedLanguage = selectedLanguage === 'pt' ? 'es' : selectedLanguage;
+
     const itemNamesInLanguage = this.items.map(
       (item) =>
-        item.names.find((name) => name.language.name === this.language)?.name
+        // item.names.find((name) => name.language.name === this.language)?.name
+      item.names.find((name) => name.language.name === selectedLanguage)?.name
     );
 
     return itemNamesInLanguage[index] || this.items[0].name;
@@ -696,13 +711,19 @@ import { PokemonService } from '../../../services/pokemon.service';
    * @return {string} The flavor text of the item in the current language.
    */
   selectedItemFlavorText(index: number): string {
+  
+    // If the language is portuguese, the item description is in spanish
+    let selectedLanguage = this.settingsService.getLanguage();
+    selectedLanguage = selectedLanguage === 'pt' ? 'es' : selectedLanguage;
+
     const itemFlavorTexts = this.items.map((item) => {
+      
       const flavorTextEntry = item.flavor_text_entries.find(
-        ({ language }) => language.name === this.settingsService.getLanguage()
+        ({ language }) => language.name === selectedLanguage
       );
       return flavorTextEntry?.text || '';
     });
-
+  
     return itemFlavorTexts[index] || '';
   }
 

--- a/src/app/components/ui-settings/ui-settings.component.html
+++ b/src/app/components/ui-settings/ui-settings.component.html
@@ -1,15 +1,32 @@
 <div class="navigation">
   <button (click)="navigateToImprint()" type="button">
-    {{ language == "en" ? "Imprint" : "Impressum" }}
+    {{ getLabel('impressum', language) }}
   </button>
-  <button (click)="navigateToCredits()" type="button">Credits</button>
+  <button (click)="navigateToCredits()" type="button">{{ getLabel('credits', language) }}</button>
 </div>
 <div (click)="toggleSettingsVisibility()" id="settings" class="settings-button">
   <div id="settings-menu" class="settings-menu d_none">
     <div class="settings-content">
-      <h3>{{ language == "en" ? "Settings" : "Einstellungen" }}</h3>
+      <h3>{{ getLabel('settings', language) }}</h3>
+
       <div class="setting language">
-        <svg
+        <label for="languageSelect">{{ getLabel('language', language) }}</label>
+        <select id="languageSelect" (click)="stopEvent($event)" (change)="setLanguage($event)">
+          <option value="en" [selected]="language == 'en'">English</option>
+          <option value="de" [selected]="language == 'de'">Deutsch</option>
+          <option value="pt" [selected]="language == 'pt'">Portuguese</option>
+        </select>
+
+        <!-- Draws each flag in svg -->
+        <svg *ngIf="language === 'de'"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512">
+          <path fill="#fc0" d="M0 341.3h512V512H0z" />
+          <path fill="#000001" d="M0 0h512v170.7H0z" />
+          <path fill="red" d="M0 170.7h512v170.6H0z" />
+        </svg>
+
+        <svg *ngIf="language === 'en'"
           xmlns="http://www.w3.org/2000/svg"
           id="flag-icons-us"
           viewBox="0 0 512 512"
@@ -30,28 +47,25 @@
             d="m0 0 18 11h65 65 65 65 66L51 39h65 65 65 65L18 66h65 65 65 65 66L51 94h65 65 65 65L18 121h65 65 65 65 66L51 149h65 65 65 65L18 177h65 65 65 65 66L51 205h65 65 65 65L18 232h65 65 65 65 66z"
           />
         </svg>
-        <label class="switch">
-          <input
-            (click)="setLanguage($event)"
-            id="languageSwitch"
-            name="language"
-            type="checkbox"
-          />
-          <span class="slider round"></span>
-        </label>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          id="flag-icons-de"
-          viewBox="0 0 512 512"
-        >
-          <path fill="#fc0" d="M0 341.3h512V512H0z" />
-          <path fill="#000001" d="M0 0h512v170.7H0z" />
-          <path fill="red" d="M0 170.7h512v170.6H0z" />
+        
+        <!-- Brazil flag -->
+        <svg *ngIf="language === 'pt'"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512">
+          <rect width="512" height="512" fill="#009739" />
+          
+          <polygon fill="#FFD700" points="256,40 466,256 256,472 46,256" />
+          
+          <circle cx="256" cy="256" r="80" fill="#3E4095" />
+
+          <text x="50%" y="50%" fill="#FFFFFF" font-size="20" font-weight="bold" text-anchor="middle" alignment-baseline="middle">Ordem e Progresso</text>
         </svg>
+
       </div>
+      
       <div class="setting">
         <label for="volume"
-          >{{ language == "en" ? "Volume" : "Lautstärke" }}:
+          >{{ getLabel('volume', language) }}:
           {{ getAudioVolume() | percent }}</label
         >
         <input
@@ -70,15 +84,13 @@
       </div>
       <div class="setting danger-zone">
         <h4 style="color: red">
-          {{ language == "en" ? "Danger Zone" : "Gefahrenbereich" }}
+          {{ getLabel('danger_zone', language) }}
         </h4>
         <h6 style="color: red">
-          {{
-            language == "en" ? "i know what i'm doing" : "ich weiß was ich tue"
-          }}
+          {{ getLabel('danger_zone_text', language) }}
         </h6>
         <h3>
-          {{ language == "en" ? "Pokemon loading limit" : "Pokemon Ladelimit" }}
+          {{ getLabel('limit', language) }}
         </h3>
         @if (!isModalOpen) { @for (limit of loadLimits; track $index) {
         <label class="limit" (click)="setPokemonLimit($event, limit)">
@@ -91,17 +103,17 @@
             [disabled]="isLoading"
           />
           Gen {{ limit.gen }} - {{ limit.limit }} @if (limit.isDefault) {
-          <span>{{ language == "en" ? "(default)" : "(standard)" }}</span>
+          <span>{{ getLabel('default', language) }}</span>
           }
         </label>
         } }@else {
         <p>{{ confirmationText }}</p>
         <div class="btn-control">
           <button (click)="handleConfirmationClick($event)" class="btn btn-yes">
-            {{ language == "en" ? "Yes" : "Ja" }}
+            {{ getLabel('yes', language) }}
           </button>
           <button (click)="handleConfirmationClick($event)" class="btn btn-no">
-            {{ language == "en" ? "No" : "Nein" }}
+            {{ getLabel('no', language) }}
           </button>
         </div>
         }

--- a/src/app/components/ui-settings/ui-settings.component.scss
+++ b/src/app/components/ui-settings/ui-settings.component.scss
@@ -101,6 +101,10 @@
           height: 0;
         }
 
+        select, select option {
+          background-color: #2196f3;
+        }
+
         .slider {
           position: absolute;
           cursor: pointer;

--- a/src/app/components/ui-settings/ui-settings.component.ts
+++ b/src/app/components/ui-settings/ui-settings.component.ts
@@ -258,10 +258,10 @@ export class UiSettingsComponent implements OnInit {
     event.stopPropagation();
   }
   setLanguage(event: Event): void {
-    const target = event.target as HTMLSelectElement;  // Agora estamos lidando com um <select>
-    const language = target.value;  // O valor selecionado ('en' ou 'de')
+    const target = event.target as HTMLSelectElement;
+    const language = target.value;  // 'en', 'de', 'pt' or other language
   
-    this.settingsService.setLanguage(language);  // Define o idioma conforme o valor selecionado
+    this.settingsService.setLanguage(language);
   }
 
   /**

--- a/src/app/components/ui-settings/ui-settings.component.ts
+++ b/src/app/components/ui-settings/ui-settings.component.ts
@@ -4,6 +4,7 @@ import { PercentPipe } from '@angular/common';
 import { Limit } from '../../../types/loadingLimits';
 import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, take } from 'rxjs';
+import { CommonModule } from '@angular/common';
 
 /**
  * Component that renders the UI settings component.
@@ -15,11 +16,59 @@ import { BehaviorSubject, Observable, take } from 'rxjs';
 @Component({
   selector: 'app-ui-settings',
   standalone: true,
-  imports: [PercentPipe],
+  imports: [PercentPipe, CommonModule ],
   templateUrl: './ui-settings.component.html',
   styleUrl: './ui-settings.component.scss',
 })
 export class UiSettingsComponent implements OnInit {
+
+  // Inserting a dictionary of translations for each language
+  getLabel = (key: string, language: string): string => {
+    const translations_dict: { [key: string]: { [key: string]: string } } = {
+      en: {
+        impressum: "Imprint",
+        credits: "Credits",
+        settings: "Settings",
+        language: "Language:",
+        volume: "Volume",
+        danger_zone: "Danger zone",
+        danger_zone_text: "i know what i'm doing",
+        limit: "Pokemon loading limit",
+        default: "(default)",
+        yes: "Yes",
+        no: "No",
+      },
+      de: {
+        impressum: "Impressum",
+        credits: "Credits",
+        settings: "Einstellungen",
+        language: "Sprache:",
+        volume: "Lautstärke",
+        danger_zone: "Gefahrenbereich",
+        danger_zone_text: "ich weiß was ich tue",
+        limit: "Pokemon Ladelimit",
+        default: "(standard)",
+        yes: "Ja",
+        no: "Nein",
+      },
+      pt: {
+        impressum: "Autoria",
+        credits: "Créditos",
+        settings: "Configurações",
+        language: "Idioma:",
+        volume: "Volume",
+        danger_zone: "Área de testes",
+        danger_zone_text: "Sei o que estou fazendo",
+        limit: "Limite de Pokémon carregados",
+        default: "(padrão)",
+        yes: "Sim",
+        no: "Não",
+      }
+    };
+  
+    // If the translation exists, returns it, case contrary, returns english(default)
+    return translations_dict[language]?.[key] || translations_dict["en"][key];
+  }
   /**
    * The available Pokémon loading limits.
    *
@@ -204,11 +253,15 @@ export class UiSettingsComponent implements OnInit {
    * @param {Event} event - The event that triggered the language update.
    * @return {void} No return value.
    */
+  // This functions stops the selector from closing before selecting the language
+  stopEvent(event: Event): void {
+    event.stopPropagation();
+  }
   setLanguage(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    const language = target.checked ? 'de' : 'en';
-
-    this.settingsService.setLanguage(language);
+    const target = event.target as HTMLSelectElement;  // Agora estamos lidando com um <select>
+    const language = target.value;  // O valor selecionado ('en' ou 'de')
+  
+    this.settingsService.setLanguage(language);  // Define o idioma conforme o valor selecionado
   }
 
   /**

--- a/src/app/services/pokemon.service.ts
+++ b/src/app/services/pokemon.service.ts
@@ -142,34 +142,35 @@ export class PokemonService {
    *
    * @param {string} type - The English name of the Pokémon type.
    *
-   * @returns {{ english: string; german: string }} An object containing both the
-   * English and German names of the Pokémon type.
+   * @returns {{ english: string; german: string, portuguese: string }} An object containing the
+   * English, German and Portuguese names of the Pokémon type.
    *
    * @example
    * const type = pokemonService.getTypeName('fire');
    * console.log(type.english); // fire
    * console.log(type.german); // Feuer
+   * console.log(type.portuguese); // Fogo
    */
-  getTypeName(type: string): { english: string; german: string } {
+  getTypeName(type: string): { english: string; german: string, portuguese: string } {
     const types = [
-      { english: 'normal', german: 'Normal' },
-      { english: 'fire', german: 'Feuer' },
-      { english: 'water', german: 'Wasser' },
-      { english: 'electric', german: 'Elektro' },
-      { english: 'grass', german: 'Pflanze' },
-      { english: 'flying', german: 'Flug' },
-      { english: 'bug', german: 'Käfer' },
-      { english: 'poison', german: 'Gift' },
-      { english: 'rock', german: 'Gestein' },
-      { english: 'ground', german: 'Boden' },
-      { english: 'fighting', german: 'Kämpfer' },
-      { english: 'ice', german: 'Eis' },
-      { english: 'psychic', german: 'Psycho' },
-      { english: 'ghost', german: 'Geist' },
-      { english: 'dragon', german: 'Drache' },
-      { english: 'fairy', german: 'Fee' },
-      { english: 'dark', german: 'Unlicht' },
-      { english: 'steel', german: 'Stahl' },
+      { english: 'normal', german: 'Normal', portuguese: 'Normal' },
+      { english: 'fire', german: 'Feuer', portuguese: 'Fogo' },
+      { english: 'water', german: 'Wasser', portuguese: 'Água' },
+      { english: 'electric', german: 'Elektro', portuguese: 'Elétrico' },
+      { english: 'grass', german: 'Pflanze', portuguese: 'Planta' },
+      { english: 'flying', german: 'Flug', portuguese: 'Voador' },
+      { english: 'bug', german: 'Käfer', portuguese: 'Inseto' },
+      { english: 'poison', german: 'Gift', portuguese: 'Venenoso' },
+      { english: 'rock', german: 'Gestein', portuguese: 'Pedra' },
+      { english: 'ground', german: 'Boden', portuguese: 'Terrestre' },
+      { english: 'fighting', german: 'Kämpfer', portuguese: 'Lutador' },
+      { english: 'ice', german: 'Eis', portuguese: 'Gelo' },
+      { english: 'psychic', german: 'Psycho', portuguese: 'Psíquico' },
+      { english: 'ghost', german: 'Geist', portuguese: 'Fantasma' },
+      { english: 'dragon', german: 'Drache', portuguese: 'Dragão' },
+      { english: 'fairy', german: 'Fee', portuguese: 'Fada' },
+      { english: 'dark', german: 'Unlicht', portuguese: 'Sombrio' },
+      { english: 'steel', german: 'Stahl', portuguese: 'Aço' },
     ];
 
     const typeObject = types.find((t) => t.english === type);


### PR DESCRIPTION
This pull request adds the Portuguese - Brazil language in the pokédex. The updates include:
- Language dropdown selector instead of switch
- Inclusion of spanish language in the portuguese descriptions, since the Pokédex API does not have official portuguese translation
- Possibility of adding a fourth language by including it in the dictionaries and and ternaries available in the code
![image](https://github.com/user-attachments/assets/6b586723-5172-47c1-b9f0-0e4b235ae847)


Final consideration:
- In some parts of the code, I couldn't add a dictionary / switch case structure, so they are built with nested ternaries inside the Angular interpolations
![image](https://github.com/user-attachments/assets/76502fb0-3c0b-416a-8fb7-90a7179bd329)
